### PR TITLE
Fix #7340 by correclty computing function name for push event

### DIFF
--- a/src/LiveQuery/ParseLiveQueryServer.js
+++ b/src/LiveQuery/ParseLiveQueryServer.js
@@ -298,7 +298,6 @@ class ParseLiveQueryServer {
             } else {
               return null;
             }
-            message.event = type;
             res = {
               event: type,
               sessionToken: client.sessionToken,
@@ -334,8 +333,7 @@ class ParseLiveQueryServer {
               originalParseObject = res.original.toJSON();
               originalParseObject.className = res.original.className || className;
             }
-            const functionName =
-              'push' + message.event.charAt(0).toUpperCase() + message.event.slice(1);
+            const functionName = 'push' + res.event.charAt(0).toUpperCase() + res.event.slice(1);
             if (client[functionName]) {
               client[functionName](requestId, currentParseObject, originalParseObject);
             }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Related issue: #7340

### Approach
<!-- Add a description of the approach in this PR. -->
First create a failing test to demonstrate the issue described by #7340. Then simply replace the update of the argument `message` by the use of the newly created `res` object.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add test cases
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
- [ ] ...